### PR TITLE
Add `kubectl reset-ns`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ See [Extend kubectl with plugins](https://kubernetes.io/docs/tasks/extend-kubect
 
 ## Plugins
 
-| Name                                   | Description                                                                    |
-|----------------------------------------|--------------------------------------------------------------------------------|
-| [`kubectl get-all`](./kubectl-get_all) | List truly all namespaced resources included custom resources (without events) |
+| Name                                     | Description                                                                    |
+|------------------------------------------|--------------------------------------------------------------------------------|
+| [`kubectl get-all`](./kubectl-get_all)   | List truly all namespaced resources included custom resources (without events) |
+| [`kubectl reset-ns`](./kubectl-reset_ns) | Delete `metadata.namespace` in manifests                                       |

--- a/kubectl-reset_ns
+++ b/kubectl-reset_ns
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+
+out = ''
+YAML.load_stream(STDIN) do |doc|
+  if doc.key?("metadata")
+    doc["metadata"].delete("namespace")
+  end
+  puts YAML.dump(doc)
+end
+
+print out
+# vim: ai ts=2 sw=2 et sts=2 ft=ruby


### PR DESCRIPTION
This kubectl plugin deletes the `metadata.namespace` field in manifests received from stdin.

```
cat app.yaml | kubectl reset-ns | kubectl apply -f- -n my-own-ns
```